### PR TITLE
fixed missing link

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   monica-app:
     image: tiredofit/monica
     container_name: monica-app
+    links:
+      - monica-db    
     labels:
       - traefik.enable=true
       - traefik.http.routers.monica.rule=Host(`monica.example.com`)


### PR DESCRIPTION
Added missing link to `monica-db` in `docker-compose.yml`.

Maybe everyone else found that issue by themself but it took me a while to understand why your example wasn't working. As soon as I figured out the missing link, everything worked for me.

Thanks for another great image!